### PR TITLE
Hotfix: Header Splitter it is not recognizing Headers from split method

### DIFF
--- a/data/test_2.md
+++ b/data/test_2.md
@@ -1,0 +1,245 @@
+---
+__Advertisement :)__
+
+- __[pica](https://nodeca.github.io/pica/demo/)__ - high quality and fast image
+  resize in browser.
+- __[babelfish](https://github.com/nodeca/babelfish/)__ - developer friendly
+  i18n with plurals support and easy syntax.
+
+You will like those projects!
+
+---
+
+# h1 Heading 8-)
+## h2 Heading
+### h3 Heading
+#### h4 Heading
+##### h5 Heading
+###### h6 Heading
+
+
+## Horizontal Rules
+
+___
+
+---
+
+***
+
+
+## Typographic replacements
+
+Enable typographer option to see result.
+
+(c) (C) (r) (R) (tm) (TM) (p) (P) +-
+
+test.. test... test..... test?..... test!....
+
+!!!!!! ???? ,,  -- ---
+
+"Smartypants, double quotes" and 'single quotes'
+
+
+## Emphasis
+
+**This is bold text**
+
+__This is bold text__
+
+*This is italic text*
+
+_This is italic text_
+
+~~Strikethrough~~
+
+
+## Blockquotes
+
+
+> Blockquotes can also be nested...
+>> ...by using additional greater-than signs right next to each other...
+> > > ...or with spaces between arrows.
+
+
+## Lists
+
+Unordered
+
++ Create a list by starting a line with `+`, `-`, or `*`
++ Sub-lists are made by indenting 2 spaces:
+  - Marker character change forces new list start:
+    * Ac tristique libero volutpat at
+    + Facilisis in pretium nisl aliquet
+    - Nulla volutpat aliquam velit
++ Very easy!
+
+Ordered
+
+1. Lorem ipsum dolor sit amet
+2. Consectetur adipiscing elit
+3. Integer molestie lorem at massa
+
+
+1. You can use sequential numbers...
+1. ...or keep all the numbers as `1.`
+
+Start numbering with offset:
+
+57. foo
+1. bar
+
+
+## Code
+
+Inline `code`
+
+Indented code
+
+    // Some comments
+    line 1 of code
+    line 2 of code
+    line 3 of code
+
+
+Block code "fences"
+
+```
+Sample text here...
+```
+
+Syntax highlighting
+
+``` js
+var foo = function (bar) {
+  return bar++;
+};
+
+console.log(foo(5));
+```
+
+## Tables
+
+| Option | Description |
+| ------ | ----------- |
+| data   | path to data files to supply the data that will be passed into templates. |
+| engine | engine to be used for processing templates. Handlebars is the default. |
+| ext    | extension to be used for dest files. |
+
+Right aligned columns
+
+| Option | Description |
+| ------:| -----------:|
+| data   | path to data files to supply the data that will be passed into templates. |
+| engine | engine to be used for processing templates. Handlebars is the default. |
+| ext    | extension to be used for dest files. |
+
+
+## Links
+
+[link text](http://dev.nodeca.com)
+
+[link with title](http://nodeca.github.io/pica/demo/ "title text!")
+
+Autoconverted link https://github.com/nodeca/pica (enable linkify to see)
+
+
+## Images
+
+![Minion](https://octodex.github.com/images/minion.png)
+![Stormtroopocat](https://octodex.github.com/images/stormtroopocat.jpg "The Stormtroopocat")
+
+Like links, Images also have a footnote style syntax
+
+![Alt text][id]
+
+With a reference later in the document defining the URL location:
+
+[id]: https://octodex.github.com/images/dojocat.jpg  "The Dojocat"
+
+
+## Plugins
+
+The killer feature of `markdown-it` is very effective support of
+[syntax plugins](https://www.npmjs.org/browse/keyword/markdown-it-plugin).
+
+
+### [Emojies](https://github.com/markdown-it/markdown-it-emoji)
+
+> Classic markup: :wink: :cry: :laughing: :yum:
+>
+> Shortcuts (emoticons): :-) :-( 8-) ;)
+
+see [how to change output](https://github.com/markdown-it/markdown-it-emoji#change-output) with twemoji.
+
+
+### [Subscript](https://github.com/markdown-it/markdown-it-sub) / [Superscript](https://github.com/markdown-it/markdown-it-sup)
+
+- 19^th^
+- H~2~O
+
+
+### [\<ins>](https://github.com/markdown-it/markdown-it-ins)
+
+++Inserted text++
+
+
+### [\<mark>](https://github.com/markdown-it/markdown-it-mark)
+
+==Marked text==
+
+
+### [Footnotes](https://github.com/markdown-it/markdown-it-footnote)
+
+Footnote 1 link[^first].
+
+Footnote 2 link[^second].
+
+Inline footnote^[Text of inline footnote] definition.
+
+Duplicated footnote reference[^second].
+
+[^first]: Footnote **can have markup**
+
+    and multiple paragraphs.
+
+[^second]: Footnote text.
+
+
+### [Definition lists](https://github.com/markdown-it/markdown-it-deflist)
+
+Term 1
+
+:   Definition 1
+with lazy continuation.
+
+Term 2 with *inline markup*
+
+:   Definition 2
+
+        { some code, part of Definition 2 }
+
+    Third paragraph of definition 2.
+
+_Compact style:_
+
+Term 1
+  ~ Definition 1
+
+Term 2
+  ~ Definition 2a
+  ~ Definition 2b
+
+
+### [Abbreviations](https://github.com/markdown-it/markdown-it-abbr)
+
+This is HTML abbreviation example.
+
+It converts "HTML", but keep intact partial entries like "xxxHTMLyyy" and so on.
+
+*[HTML]: Hyper Text Markup Language
+
+### [Custom containers](https://github.com/markdown-it/markdown-it-container)
+
+::: warning
+*here be dragons*
+:::

--- a/src/splitter_mr/reader/readers/vanilla_reader.py
+++ b/src/splitter_mr/reader/readers/vanilla_reader.py
@@ -81,7 +81,8 @@ class VanillaReader(BaseReader):
         text = ""
 
         conversion_method = None
-        if ext in ("json", "html", "txt", "xml", "csv", "tsv"):
+
+        if ext in ("json", "html", "txt", "xml", "csv", "tsv", "md", "markdown"):
             with open(file_path, "r", encoding="utf-8") as f:
                 text = f.read()
         elif ext == "parquet":

--- a/src/splitter_mr/splitter/__init__.py
+++ b/src/splitter_mr/splitter/__init__.py
@@ -1,6 +1,7 @@
 from .base_splitter import BaseSplitter
 from .splitters import (
     CharacterSplitter,
+    HeaderSplitter,
     HTMLTagSplitter,
     ParagraphSplitter,
     RecursiveCharacterSplitter,
@@ -18,4 +19,5 @@ __all__ = [
     RecursiveCharacterSplitter,
     RecursiveJSONSplitter,
     HTMLTagSplitter,
+    HeaderSplitter,
 ]

--- a/src/splitter_mr/splitter/splitters/header_splitter.py
+++ b/src/splitter_mr/splitter/splitters/header_splitter.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any, Dict, List, Optional, Tuple
 
 from bs4 import BeautifulSoup
@@ -9,109 +10,145 @@ from ..base_splitter import BaseSplitter
 
 class HeaderSplitter(BaseSplitter):
     """
-    HeaderSplitter splits a Markdown or HTML document into chunks using header levels.
+    Splits a Markdown or HTML document into chunks based on header levels.
 
-    This splitter uses Langchain's MarkdownHeaderTextSplitter or HTMLHeaderTextSplitter
-    depending on the file extension. You can configure which headers are used and their
-    semantic names (e.g., ("##", "Header 2")).
+    This splitter automatically adapts the provided list of semantic header names
+    (e.g., ["Header 1", "Header 2"]) into the appropriate header tokens for either
+    Markdown (e.g., "#", "##") or HTML (e.g., "h1", "h2"), depending on the document type.
+    It then uses Langchain's `MarkdownHeaderTextSplitter` or `HTMLHeaderTextSplitter`
+    under the hood.
 
     Args:
-        headers_to_split_on (List[Tuple[str, str]]):
-            List of tuples with Markdown or HTML header tokens and their semantic names.
-        chunk_size (int):
-            Unused but present for compatibility with the BaseSplitter API.
+        chunk_size (int, optional): Unused, kept for compatibility with BaseSplitter API.
+        headers_to_split_on (Optional[List[str]]):
+            List of semantic header names to split on. For example: ["Header 1", "Header 2", "Header 3"]
 
     Notes:
-        See [Langchain Docs on MarkdownHeaderTextSplitter](https://api.python.langchain.com/en/latest/markdown/langchain_text_splitters.markdown.MarkdownHeaderTextSplitter.html).
-        See [Langchain Docs on HTMLHeaderTextSplitter](https://python.langchain.com/api_reference/text_splitters/html/langchain_text_splitters.html.HTMLHeaderTextSplitter.html).
+        - See [Langchain MarkdownHeaderTextSplitter](https://api.python.langchain.com/en/latest/markdown/langchain_text_splitters.markdown.MarkdownHeaderTextSplitter.html)
+        - See [Langchain HTMLHeaderTextSplitter](https://python.langchain.com/api_reference/text_splitters/html/langchain_text_splitters.html.HTMLHeaderTextSplitter.html)
     """
 
     def __init__(
         self,
         chunk_size: int = 1000,
-        headers_to_split_on: Optional[List[Tuple[str, str]]] = [
-            ("#", "Header 1"),
-            ("##", "Header 2"),
-            ("####", "Header 3"),
-        ],
+        headers_to_split_on: Optional[List[str]] = ["Header 1", "Header 2", "Header 3"],
     ):
+        """
+        Initializes a HeaderSplitter instance.
+
+        Args:
+            chunk_size (int, optional): Unused parameter. Present for API compatibility.
+            headers_to_split_on (Optional[List[str]]):
+                List of header names such as ["Header 1", "Header 2"]. Defaults to first three levels.
+        """
         super().__init__(chunk_size)
         self.headers_to_split_on = headers_to_split_on
 
+    @staticmethod
+    def _header_level(header: str) -> int:
+        """
+        Extracts the numeric level from a header name like "Header 2".
+
+        Args:
+            header (str): Semantic header name (e.g., "Header 2").
+
+        Returns:
+            int: The numeric level of the header (e.g., 2 for "Header 2").
+
+        Raises:
+            ValueError: If the header string is not in the expected format.
+        """
+        m = re.match(r"header\s*(\d+)", header.lower())
+        if not m:
+            raise ValueError(f"Invalid header: {header}")
+        return int(m.group(1))
+
+    def _make_tuples(self, filetype: str) -> List[Tuple[str, str]]:
+        """
+        Converts semantic header names into tuples for Markdown or HTML splitters.
+
+        Args:
+            filetype (str): "md" for Markdown, "html" for HTML.
+
+        Returns:
+            List[Tuple[str, str]]:
+                A list of tuples where the first element is the filetype-specific header
+                token (e.g., "#", "##", "h1", "h2"), and the second is the header's semantic name.
+
+        Raises:
+            ValueError: If filetype is unknown or headers are not in the expected format.
+        """
+        result = []
+        for header in self.headers_to_split_on:
+            level = self._header_level(header)
+            if filetype == "md":
+                token = "#" * level
+            elif filetype == "html":
+                token = f"h{level}"
+            else:
+                raise ValueError(f"Unknown filetype: {filetype}")
+            result.append((token, header))
+        return result
+
     def split(self, reader_output: Dict[str, Any]) -> Dict[str, Any]:
         """
-        Splits the input document (Markdown or HTML) found in reader_output["text"] using
-            the configured headers.
+        Splits a document (Markdown or HTML) into chunks using the configured header levels.
 
         Args:
             reader_output (Dict[str, Any]):
-                Dictionary with the structure defined in the ReaderOutput schema.
-                Must contain a 'text' field (the Markdown or HTML to split) and may contain
-                document-level metadata fields such as 'document_name', 'document_path', etc.
+                Dictionary with a 'text' field containing the document content,
+                plus optional document-level metadata such as 'document_name' and 'document_path'.
 
         Returns:
-            Dict[str, Any]:
-                A dictionary matching the SplitterOutput schema with the following keys:
-                    - 'chunks': List[str], the resulting text chunks.
-                    - 'chunk_id': List[str], unique IDs for each chunk.
-                    - 'document_name': Optional[str], source document name.
-                    - 'document_path': str, source document path.
-                    - 'document_id': Optional[str], unique document identifier.
-                    - 'conversion_method': Optional[str], conversion method used.
-                    - 'ocr_method': Optional[str], OCR method used (if any).
-                    - 'split_method': str, the name of the split method ("header_splitter").
-                    - 'split_params': Dict[str, Any], parameters used for splitting.
-                    - 'metadata': Dict, document-level metadata dictionary.
+            Dict[str, Any]: Dictionary following the SplitterOutput schema with keys:
+                - 'chunks': List of chunked document strings.
+                - 'chunk_id': List of unique IDs for each chunk.
+                - 'document_name': Optional source document name.
+                - 'document_path': Source document path.
+                - 'document_id': Optional document identifier.
+                - 'conversion_method': Optional conversion method.
+                - 'ocr_method': Optional OCR method used.
+                - 'split_method': Name of the split method ("header_splitter").
+                - 'split_params': Parameters used for splitting.
+                - 'metadata': Document-level metadata dictionary.
 
         Raises:
-            ValueError: If 'text' is not present in reader_output or is empty.
-            TypeError: If 'text' comes from a non-compatible document type.
+            ValueError: If 'text' is missing from reader_output or is empty.
+            TypeError: If the document is not Markdown or HTML.
 
         Example:
             ```python
             from splitter_mr.splitter import HeaderSplitter
 
-            # This dictionary has been obtained as the output from a Reader object.
             reader_output = {
                 "text": "# Title\\n\\n## Subtitle\\nText...",
                 "document_name": "doc.md",
                 "document_path": "/path/doc.md"
             }
-            splitter = HeaderSplitter(
-                headers_to_split_on = [
-                    ("#", "Header 1"), ("##", "Header 2")
-                    ]
-                )
+            splitter = HeaderSplitter(headers_to_split_on=["Header 1", "Header 2"])
             output = splitter.split(reader_output)
-            print(output["chunks"][0])
-            ```
-            ```bash
-            ["# Title \\n \\n", "## Subtitle\\nText..."]
+            print(output["chunks"])
             ```
         """
-        # Initialize variables
-        markdown_text = reader_output.get("text", "")
+        text = reader_output.get("text", "")
+        if not text:
+            raise ValueError("reader_output must contain non-empty 'text' field.")
 
-        if bool(BeautifulSoup(markdown_text, "html.parser").find()):
-            try:
-                splitter = HTMLHeaderTextSplitter(
-                    headers_to_split_on=self.headers_to_split_on
-                )
-            except ValueError as e:
-                raise TypeError(
-                    "Incorrect Header selection for HTML splitter. Please ensure headers_to_split_on contains only HTML header tags like [('h1', 'Header 1'), ('h2', 'Header 2')], etc."  # noqa: E501
-                ) from e
+        # Detect file type and configure header tuples
+        if bool(BeautifulSoup(text, "html.parser").find()):
+            # HTML
+            tuples = self._make_tuples("html")
+            splitter = HTMLHeaderTextSplitter(
+                headers_to_split_on=tuples, return_each_element=True
+            )
         else:
-            try:
-                splitter = MarkdownHeaderTextSplitter(
-                    headers_to_split_on=self.headers_to_split_on
-                )
-            except ValueError as e:
-                raise ValueError(
-                    "Incorrect Header selection for Markdown Splitter. Please ensure headers_to_split_on contains only Markdown header tags like [('#', 'Header 1'), ('##', 'Header 2')], etc."  # noqa: E501
-                ) from e
+            # Markdown
+            tuples = self._make_tuples("md")
+            splitter = MarkdownHeaderTextSplitter(
+                headers_to_split_on=tuples, return_each_line=True
+            )
 
-        docs = splitter.split_text(markdown_text)
+        docs = splitter.split_text(text)
         chunks = [doc.page_content for doc in docs]
         chunk_ids = self._generate_chunk_ids(len(chunks))
         metadata = self._default_metadata()

--- a/tests/splitter_mr/splitter/splitters/test_header_splitter.py
+++ b/tests/splitter_mr/splitter/splitters/test_header_splitter.py
@@ -30,7 +30,7 @@ def html_reader_output():
 
 
 def test_uses_html_splitter_on_html_content(html_reader_output):
-    # Should use HTMLHeaderTextSplitter when any tag is found
+    # Should use HTMLHeaderTextSplitter and convert headers_to_split_on internally
     with (
         patch(
             "splitter_mr.splitter.splitters.header_splitter.HTMLHeaderTextSplitter"
@@ -41,12 +41,12 @@ def test_uses_html_splitter_on_html_content(html_reader_output):
     ):
         mock_html = MockHTML.return_value
         mock_html.split_text.return_value = [MagicMock(page_content="HTML Chunk")]
-        splitter = HeaderSplitter(
-            headers_to_split_on=[("h1", "Header 1"), ("h2", "Header 2")]
-        )
+        splitter = HeaderSplitter(headers_to_split_on=["Header 1", "Header 2"])
         result = splitter.split(html_reader_output)
+        # The splitter should convert ["Header 1", "Header 2"] to [("h1", "Header 1"), ("h2", "Header 2")]
         MockHTML.assert_called_once_with(
-            headers_to_split_on=[("h1", "Header 1"), ("h2", "Header 2")]
+            headers_to_split_on=[("h1", "Header 1"), ("h2", "Header 2")],
+            return_each_element=True,
         )
         mock_html.split_text.assert_called_once_with(html_reader_output["text"])
         MockMD.assert_not_called()
@@ -55,7 +55,7 @@ def test_uses_html_splitter_on_html_content(html_reader_output):
 
 
 def test_uses_markdown_splitter_on_md_content(markdown_reader_output):
-    # Should use MarkdownHeaderTextSplitter when no HTML tags found
+    # Should use MarkdownHeaderTextSplitter and convert headers_to_split_on internally
     with (
         patch(
             "splitter_mr.splitter.splitters.header_splitter.MarkdownHeaderTextSplitter"
@@ -66,12 +66,12 @@ def test_uses_markdown_splitter_on_md_content(markdown_reader_output):
     ):
         mock_md = MockMD.return_value
         mock_md.split_text.return_value = [MagicMock(page_content="MD Chunk")]
-        splitter = HeaderSplitter(
-            headers_to_split_on=[("#", "Header 1"), ("##", "Header 2")]
-        )
+        splitter = HeaderSplitter(headers_to_split_on=["Header 1", "Header 2"])
         result = splitter.split(markdown_reader_output)
+        # The splitter should convert ["Header 1", "Header 2"] to [("#", "Header 1"), ("##", "Header 2")]
         MockMD.assert_called_once_with(
-            headers_to_split_on=[("#", "Header 1"), ("##", "Header 2")]
+            headers_to_split_on=[("#", "Header 1"), ("##", "Header 2")],
+            return_each_line=True,
         )
         mock_md.split_text.assert_called_once_with(markdown_reader_output["text"])
         MockHTML.assert_not_called()
@@ -79,28 +79,11 @@ def test_uses_markdown_splitter_on_md_content(markdown_reader_output):
         assert result["split_method"] == "header_splitter"
 
 
-def test_value_error_on_bad_markdown_headers(markdown_reader_output):
-    with patch(
-        "splitter_mr.splitter.splitters.header_splitter.MarkdownHeaderTextSplitter"
-    ) as MockMD:
-        MockMD.side_effect = ValueError("bad headers")
-        splitter = HeaderSplitter(headers_to_split_on=[("NOPE", "bad")])
-        with pytest.raises(
-            ValueError, match="Incorrect Header selection for Markdown Splitter"
-        ):
-            splitter.split(markdown_reader_output)
-
-
-def test_type_error_on_bad_html_headers(html_reader_output):
-    with patch(
-        "splitter_mr.splitter.splitters.header_splitter.HTMLHeaderTextSplitter"
-    ) as MockHTML:
-        MockHTML.side_effect = ValueError("bad headers")
-        splitter = HeaderSplitter(headers_to_split_on=[("NOPE", "bad")])
-        with pytest.raises(
-            TypeError, match="Incorrect Header selection for HTML splitter"
-        ):
-            splitter.split(html_reader_output)
+def test_value_error_on_bad_semantic_header(markdown_reader_output):
+    # Should raise ValueError for invalid header names
+    splitter = HeaderSplitter(headers_to_split_on=["NOPE", "Header 2"])
+    with pytest.raises(ValueError, match="Invalid header: NOPE"):
+        splitter.split(markdown_reader_output)
 
 
 def test_output_metadata_fields(markdown_reader_output):
@@ -127,7 +110,7 @@ def test_output_metadata_fields(markdown_reader_output):
 
 
 def test_html_dispatch_on_html_fragment():
-    # Should dispatch to HTML splitter even for small fragments
+    # Should dispatch to HTML splitter even for small HTML fragments
     html_fragment = "<div>Only one tag</div>"
     reader_output = {
         "text": html_fragment,
@@ -140,7 +123,11 @@ def test_html_dispatch_on_html_fragment():
     ) as MockHTML:
         mock_html = MockHTML.return_value
         mock_html.split_text.return_value = [MagicMock(page_content="HTML Chunk")]
-        splitter = HeaderSplitter(headers_to_split_on=[("div", "Div")])
+        splitter = HeaderSplitter(headers_to_split_on=["Header 1"])
         result = splitter.split(reader_output)
-        MockHTML.assert_called_once()
+        # "Header 1" -> [("h1", "Header 1")]
+        MockHTML.assert_called_once_with(
+            headers_to_split_on=[("h1", "Header 1")],
+            return_each_element=True,
+        )
         assert result["chunks"] == ["HTML Chunk"]


### PR DESCRIPTION
**Header Splitter:** Not Recognizing Headers from the `split` Method

**Solution:** Change the attribute `headers_to_split_on` within the `HeaderSplitter` to a list of strings containing the names of the headers to split on, instead of a tuple. This attribute is now more flexible, allowing for easier splitting regardless of whether you are working with Markdown or HTML files.